### PR TITLE
Add IYamlStreamProvider and ZipStreamProvider

### DIFF
--- a/src/AzurePipelineParser/AzurePipelineParser.csproj
+++ b/src/AzurePipelineParser/AzurePipelineParser.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <Nullable>enable</Nullable>
-	<LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AzurePipelineParser/Models/YamlStreamProviders/IYamlStreamProvider.cs
+++ b/src/AzurePipelineParser/Models/YamlStreamProviders/IYamlStreamProvider.cs
@@ -1,5 +1,4 @@
-﻿
-using System.IO;
+﻿using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,6 +6,6 @@ namespace AzurePipelineParser.Models.YamlStreamProviders
 {
     public interface IYamlStreamProvider
     {
-        Task<Stream> GetStreamFromPath(string path, CancellationToken cancellationToken = default); 
+        Task<Stream> GetStreamFromPathAsync(string path, CancellationToken cancellationToken = default); 
     }
 }

--- a/src/AzurePipelineParser/Models/YamlStreamProviders/IYamlStreamProvider.cs
+++ b/src/AzurePipelineParser/Models/YamlStreamProviders/IYamlStreamProvider.cs
@@ -1,10 +1,12 @@
 ﻿
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace AzurePipelineParser.Models.YamlStreamProviders
 {
     public interface IYamlStreamProvider
     {
-        Stream GetStreamFromPath(string path); 
+        Task<Stream> GetStreamFromPath(string path, CancellationToken cancellationToken = default); 
     }
 }

--- a/src/AzurePipelineParser/Models/YamlStreamProviders/IYamlStreamProvider.cs
+++ b/src/AzurePipelineParser/Models/YamlStreamProviders/IYamlStreamProvider.cs
@@ -1,0 +1,10 @@
+﻿
+using System.IO;
+
+namespace AzurePipelineParser.Models.YamlStreamProviders
+{
+    public interface IYamlStreamProvider
+    {
+        Stream GetStreamFromPath(string path); 
+    }
+}

--- a/src/AzurePipelineParser/Models/YamlStreamProviders/ZipStreamProvider.cs
+++ b/src/AzurePipelineParser/Models/YamlStreamProviders/ZipStreamProvider.cs
@@ -20,29 +20,26 @@ namespace AzurePipelineParser.Models.YamlStreamProviders
             _zipStreamData = new Lazy<ConcurrentDictionary<string, Stream>>(InitZipStreamData);
         }
 
-        public async Task<Stream> GetStreamFromPath(string path, CancellationToken cancellationToken = default)
+        public Task<Stream> GetStreamFromPathAsync(string path, CancellationToken cancellationToken = default)
         {
             ConcurrentDictionary<string, Stream> dictionary = _zipStreamData.Value;
 
-            return await Task.Run(() =>
+            if (path.StartsWith('/'))
             {
-                if (path.StartsWith('/'))
-                {
-                    path = path.TrimStart('/');
-                }
+                path = path.TrimStart('/');
+            }
 
-                if (!dictionary.TryGetValue(path, out Stream result))
-                {
-                    throw new FileNotFoundException(path);
-                }
+            if (!dictionary.TryGetValue(path, out Stream result))
+            {
+                throw new FileNotFoundException(path);
+            }
 
-                if (result.CanSeek && result.Position > 0)
-                {
-                    result.Seek(0, SeekOrigin.Begin);
-                }
+            if (result.CanSeek && result.Position > 0)
+            {
+                result.Seek(0, SeekOrigin.Begin);
+            }
 
-                return result;
-            }, cancellationToken);
+            return Task.FromResult(result);
         }
 
         public async ValueTask DisposeAsync()

--- a/src/AzurePipelineParser/Models/YamlStreamProviders/ZipStreamProvider.cs
+++ b/src/AzurePipelineParser/Models/YamlStreamProviders/ZipStreamProvider.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AzurePipelineParser.Models.YamlStreamProviders
+{
+    public class ZipStreamProvider : IYamlStreamProvider, IAsyncDisposable
+    {
+        private Stream? _zipStream;
+        private Lazy<Dictionary<string, Stream>> _zipStreamData;
+        private ZipArchive _zipArchive;
+
+        public ZipStreamProvider(Stream zipStream)
+        {
+            _zipStream = zipStream;
+            _zipArchive = new ZipArchive(_zipStream, ZipArchiveMode.Read, leaveOpen: true);
+            _zipStreamData = new Lazy<Dictionary<string, Stream>>(InitZipStreamData);
+        }
+
+        public Stream GetStreamFromPath(string path)
+        {
+            if (path.StartsWith('/'))
+            {
+                path = path.TrimStart('/');
+            }
+
+            if (!_zipStreamData.Value.TryGetValue(path, out Stream result))
+            {
+                throw new FileNotFoundException(path);
+            }
+
+            if (result.CanSeek && result.Position > 0)
+            {
+                result.Seek(0, SeekOrigin.Begin);
+            }
+
+            return result;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_zipArchive != null)
+            {
+                _zipArchive.Dispose();
+                _zipArchive = null!;
+            }
+
+            if (_zipStream != null)
+            {
+                _zipStream.Dispose();
+                _zipStream = null;
+            }
+
+            if (_zipStreamData != null && _zipStreamData.IsValueCreated)
+            {
+                foreach (Stream stream in _zipStreamData.Value.Values)
+                    await stream.DisposeAsync();
+
+                _zipStreamData.Value.Clear();
+                _zipStreamData = null!;
+            }
+        }
+
+        private Dictionary<string, Stream> InitZipStreamData()
+        {
+            Dictionary<string, Stream> data = new(_zipArchive.Entries.Count);
+            foreach (ZipArchiveEntry entry in _zipArchive.Entries)
+            {
+                if (entry.Name.EndsWith(".yml", StringComparison.OrdinalIgnoreCase))
+                {
+                    data.Add(entry.FullName, entry.Open());
+                }
+            }
+
+            return data;
+        }
+    }
+}


### PR DESCRIPTION
This provides an interface for the parser to use in order to get the yaml files, this way we can expand the source of the yaml files to be from different providers (i.e Github, AzDo, etc). Also, I added an implementation to get yaml files from a .zip archive.

The path for the files within the .zip archive need to be relative to the archive. 