### PR TITLE
Add UI support to pick or drop a .zip file to use it as the yaml source

### DIFF
--- a/src/front/Pages/Index.razor
+++ b/src/front/Pages/Index.razor
@@ -1,6 +1,4 @@
 ﻿@page "/"
-@inject HttpClient Http
-@inject IJSRuntime JS
 
 <PageTitle>Index</PageTitle>
 
@@ -28,54 +26,6 @@ else
             <p class="upload-file-text">@(_currentFile == null ? "Please select or a zip file with all the yaml files used in your azure pipeline" : _currentFile.Name)</p>
         </div>
         <div class="col-sm-3"></div>
-        <InputFile OnChange="@OnChange" @ref="fileInput" style="display:none" id="file-input" accept=".zip"/>
+        <InputFile OnChange="@OnInputFileChanged" @ref="fileInput" style="display:none" id="file-input" accept=".zip"/>
     </div>
-}
-
-@code {
-    private YamlNodeModel? _root = null;
-    private bool _loadingTree = false;
-    private bool _shouldShowTree = false;
-    private InputFile? fileInput;
-    private ElementReference? clickContainerElement;
-    private ElementReference? uploadFileText;
-    private IJSObjectReference? _clickContainerInstance;
-    private IBrowserFile? _currentFile = null;
-
-    protected override async Task OnInitializedAsync()
-    {
-        _loadingTree = true;
-        _root = await Http!.GetFromJsonAsync<YamlNodeModel>("sample-data/yaml-tree.json");
-    }
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender)
-        {
-            // Initialize the drop zone
-            _clickContainerInstance = await JS.InvokeAsync<IJSObjectReference>("interopFunctions.initializeClickElement", clickContainerElement, fileInput!.Element);
-        }
-    }
-
-
-    private void OnChange(InputFileChangeEventArgs e)
-    {
-        if (e.File.ContentType != "application/x-zip-compressed")
-        {
-            // TODO show error.
-            return;
-        }
-
-        _currentFile = e.File;
-
-    }
-
-    public async ValueTask DisposeAsync()
-    {
-        if (_clickContainerInstance != null)
-        {
-            await _clickContainerInstance.InvokeVoidAsync("dispose");
-            await _clickContainerInstance.DisposeAsync();
-        }
-    }
 }

--- a/src/front/Pages/Index.razor
+++ b/src/front/Pages/Index.razor
@@ -1,25 +1,81 @@
 ﻿@page "/"
 @inject HttpClient Http
+@inject IJSRuntime JS
 
 <PageTitle>Index</PageTitle>
 
-@if (_root == null)
+@if (_shouldShowTree)
 {
-    <div class="loading-container full-page">
-        <div class="spinner-grow text-primary" role="status">
-            <span class="visually-hidden">Loading...</span>
+    @if (_loadingTree)
+    {
+        <div class="loading-container full-page">
+            <div class="spinner-grow text-primary" role="status">
+                <span class="visually-hidden">Loading...</span>
+            </div>
         </div>
-    </div>
+    }
+    else
+    {
+        <YamlNode Node="@_root" />
+    }
 }
 else
 {
-    <YamlNode Node="@_root" />
+    <div class="row">
+        <div class="col-sm-3"></div>
+        <div class="file-picker-container col-sm-6" @ref="clickContainerElement">
+            <p class="icon-container"><i class="bi bi-file-zip"></i></p>
+            <p class="upload-file-text">@(_currentFile == null ? "Please select or a zip file with all the yaml files used in your azure pipeline" : _currentFile.Name)</p>
+        </div>
+        <div class="col-sm-3"></div>
+        <InputFile OnChange="@OnChange" @ref="fileInput" style="display:none" id="file-input" accept=".zip"/>
+    </div>
 }
 
 @code {
     private YamlNodeModel? _root = null;
+    private bool _loadingTree = false;
+    private bool _shouldShowTree = false;
+    private InputFile? fileInput;
+    private ElementReference? clickContainerElement;
+    private ElementReference? uploadFileText;
+    private IJSObjectReference? _clickContainerInstance;
+    private IBrowserFile? _currentFile = null;
+
     protected override async Task OnInitializedAsync()
     {
+        _loadingTree = true;
         _root = await Http!.GetFromJsonAsync<YamlNodeModel>("sample-data/yaml-tree.json");
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            // Initialize the drop zone
+            _clickContainerInstance = await JS.InvokeAsync<IJSObjectReference>("interopFunctions.initializeClickElement", clickContainerElement, fileInput!.Element);
+        }
+    }
+
+
+    private void OnChange(InputFileChangeEventArgs e)
+    {
+        if (e.File.ContentType != "application/x-zip-compressed")
+        {
+            // TODO show error.
+            return;
+        }
+
+        _currentFile = e.File;
+
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_clickContainerInstance != null)
+        {
+            await _clickContainerInstance.InvokeVoidAsync("dispose");
+            await _clickContainerInstance.DisposeAsync();
+        }
     }
 }

--- a/src/front/Pages/Index.razor.cs
+++ b/src/front/Pages/Index.razor.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.JSInterop;
+using System.Net.Http.Json;
+using yamltreeviewer.Shared;
+
+namespace yamltreeviewer.Pages
+{
+    public partial class Index : IAsyncDisposable
+    {
+        private YamlNodeModel? _root = null;
+        private bool _loadingTree = false;
+        private bool _shouldShowTree = false;
+        private InputFile? fileInput;
+        private ElementReference? clickContainerElement;
+        private IJSObjectReference? _clickContainerInstance;
+        private IBrowserFile? _currentFile = null;
+
+        [Inject]
+        public HttpClient? Http { get; set; }
+
+        [Inject]
+        public IJSRuntime? JS { get; set; }
+
+        protected override async Task OnInitializedAsync()
+        {
+            _loadingTree = true;
+            _root = await Http!.GetFromJsonAsync<YamlNodeModel>("sample-data/yaml-tree.json");
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+            {
+                // Initialize the drop zone
+                _clickContainerInstance = await JS!.InvokeAsync<IJSObjectReference>("interopFunctions.initializeClickElement", clickContainerElement, fileInput!.Element);
+            }
+        }
+
+
+        private void OnInputFileChanged(InputFileChangeEventArgs e)
+        {
+            if (e.File.ContentType != "application/x-zip-compressed")
+            {
+                // TODO show error.
+                return;
+            }
+
+            _currentFile = e.File;
+
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_clickContainerInstance != null)
+            {
+                await _clickContainerInstance.InvokeVoidAsync("dispose");
+                await _clickContainerInstance.DisposeAsync();
+            }
+        }
+    }
+}

--- a/src/front/Pages/Index.razor.css
+++ b/src/front/Pages/Index.razor.css
@@ -1,25 +1,22 @@
-﻿.loading-container {
-    text-align: center;
-    height: 100%;
-    width: 100%;
-    position: absolute;
-    top: 0;
-    left: 0;
-    z-index: 50;
-    background-color: rgba(255,255,255,0.8);
+﻿.file-picker-container {
+    position: relative;
+    padding: 10px;
+    border-radius: 20px;
+    box-shadow: 1px 1px 5px lightgrey;
+    cursor: pointer;
+    transition: box-shadow linear 0.5s;
 }
 
-    .loading-container.full-page {
-        position: fixed;
-        top: 56px;
-        height: 100vh;
-        width: 100vw;
+    .file-picker-container:hover {
+        box-shadow: 1px 1px 15px lightgrey;
     }
 
-        .loading-container.full-page > .spinner-grow {
-            position: absolute;
-            top: 45%;
-            left: 45%;
-            width: 60px;
-            height: 60px;
-        }
+    .file-picker-container > p {
+        text-align: center;
+    }
+
+    .file-picker-container > .icon-container {
+        font-size: 80px;
+        color: #751aff;
+        opacity: 0.4;
+    }

--- a/src/front/wwwroot/css/app.css
+++ b/src/front/wwwroot/css/app.css
@@ -39,6 +39,33 @@ a, .btn-link {
     outline: 1px solid red;
 }
 
+.loading-container {
+    text-align: center;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 50;
+    background-color: rgba(255,255,255,0.8);
+}
+
+    .loading-container.full-page {
+        position: fixed;
+        top: 56px;
+        height: 100vh;
+        width: 100vw;
+    }
+
+        .loading-container.full-page > .spinner-grow {
+            position: absolute;
+            top: 45%;
+            left: 45%;
+            width: 60px;
+            height: 60px;
+        }
+
+
 .validation-message {
     color: red;
 }

--- a/src/front/wwwroot/index.html
+++ b/src/front/wwwroot/index.html
@@ -12,7 +12,13 @@
 </head>
 
 <body>
-    <div id="app">Loading...</div>
+    <div id="app">
+        <div class="loading-container full-page">
+            <div class="spinner-grow text-primary" role="status">
+                <span class="visually-hidden">Loading...</span>
+            </div>
+        </div>
+    </div>
 
     <div id="blazor-error-ui">
         An unhandled error has occurred.
@@ -20,6 +26,56 @@
         <a class="dismiss">🗙</a>
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
+    <script>
+        window.interopFunctions = {
+            clickElement: function (element) {
+                element.click();
+            },
+
+            initializeClickElement : function (clickElement, inputFile) {
+
+                function onClick(e) {
+                    e.preventDefault();
+                    inputFile.click();
+                }
+
+                function onDragHover(e) {
+                    e.preventDefault();
+                    clickElement.classList.add("hover");
+                }
+
+                function onDragLeave(e) {
+                    e.preventDefault();
+                    clickElement.classList.remove("hover");
+                }
+
+                function onDrop(e) {
+                    console.log("handling drop");
+                    e.preventDefault();
+
+                    inputFile.files = e.dataTransfer.files;
+                    const event = new Event('change', { bubbles: true });
+                    inputFile.dispatchEvent(event);
+                }
+
+                clickElement.addEventListener("click", onClick);
+                clickElement.addEventListener("drop", onDrop);
+                clickElement.addEventListener("dragenter", onDragHover);
+                clickElement.addEventListener("dragover", onDragHover);
+                clickElement.addEventListener("dragleave", onDragLeave);
+
+                return {
+                    dispose: () => {
+                        clickElement.removeEventListener('click', onClick);
+                        clickElement.removeEventListener('drop', onDrop);
+                        clickElement.removeEventListener("dragenter", onDragHover);
+                        clickElement.removeEventListener("dragover", onDragHover);
+                        clickElement.removeEventListener("dragleave", onDragLeave);
+                    }
+                }
+            }
+        }
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
This adds a UI with support to drag and drop or pick a file from the file picker.

Functionality to specify the main yaml path and validation will add it on a separate PR.